### PR TITLE
TOSM3-Added-Black-Formatter-For-Precommit

### DIFF
--- a/scripts/config/pre-commit.yaml
+++ b/scripts/config/pre-commit.yaml
@@ -15,6 +15,12 @@ repos:
       - id: pretty-format-json
         args: ['--autofix']
     # -   id: ...
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+      - id: black
+        args: [--line-length=88]
+        language_version: python3.9
   - repo: local
     hooks:
       - id: sort-dictionary


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
Added the Black formatter for Python to run on our pre-commit for the repo

- [X] New feature (non-breaking change which adds functionality)
